### PR TITLE
Adds async support, bumps version to 1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bus"
-version = "1.2.0"
+version = "1.3.0"
 
 description = "A lock-free, bounded, single-producer, multi-consumer, broadcast channel."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,18 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "jonhoo/bus" }
 
 [features]
+async = ["futures", "void"]
 bench = []
 
 [dependencies]
-num_cpus = "0.2"
 atomic-option = "0.1"
+futures = { optional = true, version = "0.1" }
+num_cpus = "0.2"
 parking_lot_core = "0.1"
+void = { optional = true, version = "1.0" }
 
 [profile.release]
-debug=true
+debug = true
 
 [[bin]]
 name = "bench"


### PR DESCRIPTION
This adds an impl of [`futures::Stream`](https://docs.rs/futures/0.1.13/futures/stream/trait.Stream.html) to BusReader, gated behind the `async` feature.