### PR TITLE
Bump to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bus"
 version = "2.3.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 readme = "README.md"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2018"
+edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@
 //! ```
 
 #![deny(missing_docs)]
-#![warn(rust_2018_idioms)]
+#![warn(rust_2018_idioms, rust_2021_compatibility)]
 
 use crossbeam_channel as mpsc;
 use parking_lot_core::SpinWait;


### PR DESCRIPTION
This bumps the edition in both `Cargo.toml` and `rustfmt.toml` to the 2021 edition and adds the `rust_2021_compatibility` lint as a warning. `cargo fix` made no changes and all the tests still passed locally after the edition bump so hopefully this is an easy merge!