### PR TITLE
Add Bus::rx_count() to get the count of active readers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,7 +568,7 @@ impl<T> Bus<T> {
     /// Returns the number of active consumers currently attached to this bus.
     ///
     /// It is not guaranteed that a sent message will reach this number of consumers. Active
-    /// consumbers may never call `recv` or `try_recv` again before dropping.
+    /// consumers may never call `recv` or `try_recv` again before dropping.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,7 +567,7 @@ impl<T> Bus<T> {
 
     /// Returns the number of active consumers currently attached to this bus.
     ///
-    /// It is not guaranteed that a sent message will reach this number of consumers. Active
+    /// It is not guaranteed that a sent message will reach this number of consumers, as active
     /// consumers may never call `recv` or `try_recv` again before dropping.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,6 +564,29 @@ impl<T> Bus<T> {
             closed: false,
         }
     }
+
+    /// Returns the number of active consumers currently attached to this bus.
+    ///
+    /// It is not guaranteed that a sent message will reach this number of consumers. Active
+    /// consumbers may never call `recv` or `try_recv` again before dropping.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bus::Bus;
+    ///
+    /// let mut bus = Bus::<u8>::new(10);
+    /// assert_eq!(bus.rx_count(), 0);
+    ///
+    /// let rx1 = bus.add_rx();
+    /// assert_eq!(bus.rx_count(), 1);
+    ///
+    /// drop(rx1);
+    /// assert_eq!(bus.rx_count(), 0);
+    /// ```
+    pub fn rx_count(&self) -> usize {
+        self.readers - self.leaving.1.len()
+    }
 }
 
 impl<T> Drop for Bus<T> {


### PR DESCRIPTION
For our use case, we want to close the sending service once all readers have dropped, so we need a way to know how many readers are still alive. Adding a simple function in this crate, since this information is already tracked.
Toki's `broadcast` has a similar function: https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html#method.receiver_count