### PR TITLE
Add a name to unpacking thread

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,11 +344,13 @@ impl<T> Bus<T> {
         // so we don't have to wait for unpark() to return in broadcast_inner
         // sending on a channel without contention is cheap, unparking is not
         let (unpark_tx, unpark_rx) = mpsc::unbounded::<thread::Thread>();
-        thread::spawn(move || {
-            for t in unpark_rx.iter() {
-                t.unpark();
-            }
-        });
+        let _ = thread::Builder::new()
+            .name("bus_unparking".to_owned())
+            .spawn(move || {
+                for t in unpark_rx.iter() {
+                    t.unpark();
+                }
+            });
 
         Bus {
             state: inner,


### PR DESCRIPTION
We recently noticed some unnamed threads & we tracked 5 down to this crate :)
If interested, I can add a `with_thread_name` function as well, although any name is good enough for us.